### PR TITLE
Does not display the layer in the copyright table when no attribution

### DIFF
--- a/web_modules/portal/src/components/page/CopyrightComponent.jsx
+++ b/web_modules/portal/src/components/page/CopyrightComponent.jsx
@@ -67,18 +67,28 @@ export class CopyrightComponent extends React.Component {
 
   getLayerCopyrights = layer => (
     <TableRow key={layer.id}>
+     // Does not display the layer name when no attribution
+     { layer.attribution ? (
       <TableRowColumn>
         {layer.name}
       </TableRowColumn>
-      <TableRowColumn style={CopyrightComponent.labNameStyle}>
-        {layer.copyrightURL ? (
+     ) : (
+      <TableRowColumn></TableRowColumn>
+     )}
+     
+      { layer.attribution ? (
+	<TableRowColumn style={CopyrightComponent.labNameStyle}>
+	 { layer.copyrightURL ? (
           <a href={layer.copyrightURL} target="_blank">
             <span dangerouslySetInnerHTML={{ __html: layer.attribution }} />
           </a>
-        ) : (
-          <span dangerouslySetInnerHTML={{ __html: layer.attribution }} />
-          )}
-      </TableRowColumn>
+	 ) : (
+ 	  <span dangerouslySetInnerHTML={{ __html: layer.attribution }} />
+	 )}
+	</TableRowColumn>
+      ) : (
+	<TableRowColumn style={CopyrightComponent.labNameStyle}></TableRowColumn>
+      )}
     </TableRow>
   )
 
@@ -118,7 +128,7 @@ export class CopyrightComponent extends React.Component {
                 deselectOnClickaway={false}
               >
                 {map(this.props.layerList, layer => (
-                  this.getLayerCopyrights(layer)
+		  this.getLayerCopyrights(layer)
                 ))}
                 {map(this.props.globalLayerList, layer => (
                   this.getLayerCopyrights(layer)


### PR DESCRIPTION
Ce pull request permet de ne pas afficher le "layer name" dans le composant "copyright" lorsqu'une attribution n'est pas mise. 